### PR TITLE
Feature/rf 01] autenticar administrador (backend)

### DIFF
--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -1,12 +1,64 @@
 {
   "version": "5",
   "specifiers": {
+    "npm:@supabase/supabase-js@2": "2.106.2",
     "npm:bcryptjs@*": "3.0.3"
   },
   "npm": {
+    "@supabase/auth-js@2.106.2": {
+      "integrity": "sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.106.2": {
+      "integrity": "sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.106.2": {
+      "integrity": "sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.106.2": {
+      "integrity": "sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.106.2": {
+      "integrity": "sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.106.2": {
+      "integrity": "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
     "bcryptjs@3.0.3": {
       "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
       "bin": true
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     }
   },
   "remote": {

--- a/backend/supabase/functions/_shared/validacao.ts
+++ b/backend/supabase/functions/_shared/validacao.ts
@@ -1,0 +1,27 @@
+// Validação de e-mail compartilhada entre as funções.
+// Exige formato válido (com "@") e domínio na lista de provedores conhecidos.
+
+export const DOMINIOS_PERMITIDOS = [
+  "gmail.com",
+  "outlook.com",
+  "outlook.com.br",
+  "hotmail.com",
+  "hotmail.com.br",
+  "live.com",
+  "yahoo.com",
+  "yahoo.com.br",
+  "icloud.com",
+  "proton.me",
+  "protonmail.com",
+];
+
+const FORMATO_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validarEmail(email: unknown): boolean {
+  if (typeof email !== "string") return false;
+  const normalizado = email.trim().toLowerCase();
+  if (!FORMATO_EMAIL.test(normalizado)) return false;
+
+  const dominio = normalizado.split("@")[1];
+  return DOMINIOS_PERMITIDOS.includes(dominio);
+}

--- a/backend/supabase/functions/usuarios/handler.test.ts
+++ b/backend/supabase/functions/usuarios/handler.test.ts
@@ -89,8 +89,12 @@ function reqComToken(url: string, init: RequestInit = {}) {
 
 // POST login
 
-Deno.test("POST login retorna token com credenciais válidas", async () => {
-  const mock = createMockSupabase({ authUser: MOCK_USER, session: MOCK_SESSION });
+Deno.test("POST login retorna token com credenciais válidas de admin", async () => {
+  const mock = createMockSupabase({
+    authUser: MOCK_USER,
+    session: MOCK_SESSION,
+    dbData: { papel: "admin" },
+  });
 
   const req = new Request("http://localhost/usuarios?action=login", {
     method: "POST",
@@ -103,6 +107,25 @@ Deno.test("POST login retorna token com credenciais válidas", async () => {
   const body = await res.json();
   assertEquals(body.autenticado, true);
   assertEquals(body.token, MOCK_TOKEN);
+  assertEquals(body.usuario.papel, "admin");
+});
+
+Deno.test("POST login retorna 403 quando usuário não é admin", async () => {
+  const mock = createMockSupabase({
+    authUser: MOCK_USER,
+    session: MOCK_SESSION,
+    dbData: { papel: "usuario" },
+  });
+
+  const req = new Request("http://localhost/usuarios?action=login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "ana@email.com", password: "senha123" }),
+  });
+  const res = await handleUsuarios(req, mock);
+
+  assertEquals(res.status, 403);
+  assertEquals((await res.json()).autenticado, false);
 });
 
 Deno.test("POST login retorna 401 com credenciais inválidas", async () => {
@@ -175,13 +198,13 @@ Deno.test("GET perfil retorna 400 quando banco retorna erro", async () => {
 // POST criar conta
 
 Deno.test("POST cria conta com dados válidos", async () => {
-  const perfil = { id: "uuid-1", nome: "Bruno", email: "bruno@email.com" };
+  const perfil = { id: "uuid-1", nome: "Bruno", email: "bruno@gmail.com" };
   const mock = createMockSupabase({ dbData: perfil, authUser: MOCK_USER });
 
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "bruno@email.com", password: "senha123" }),
+    body: JSON.stringify({ name: "Bruno", email: "bruno@gmail.com", password: "senha123" }),
   });
   const res = await handleUsuarios(req, mock);
 
@@ -204,13 +227,39 @@ Deno.test("POST retorna 422 quando campos obrigatórios faltam", async () => {
   assertEquals(res.status, 422);
 });
 
+Deno.test("POST retorna 422 quando email não tem @", async () => {
+  const mock = createMockSupabase({ authUser: MOCK_USER });
+
+  const req = new Request("http://localhost/usuarios", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Bruno", email: "brunoemail.com", password: "senha123" }),
+  });
+  const res = await handleUsuarios(req, mock);
+
+  assertEquals(res.status, 422);
+});
+
+Deno.test("POST retorna 422 quando domínio do email não é permitido", async () => {
+  const mock = createMockSupabase({ authUser: MOCK_USER });
+
+  const req = new Request("http://localhost/usuarios", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Bruno", email: "bruno@dominioqualquer.xyz", password: "senha123" }),
+  });
+  const res = await handleUsuarios(req, mock);
+
+  assertEquals(res.status, 422);
+});
+
 Deno.test("POST retorna 400 quando auth retorna erro (email duplicado)", async () => {
   const mock = createMockSupabase({ authError: { message: "User already registered" } });
 
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "bruno@email.com", password: "senha123" }),
+    body: JSON.stringify({ name: "Bruno", email: "bruno@gmail.com", password: "senha123" }),
   });
   const res = await handleUsuarios(req, mock);
 

--- a/backend/supabase/functions/usuarios/handler.test.ts
+++ b/backend/supabase/functions/usuarios/handler.test.ts
@@ -11,7 +11,9 @@ function createMockSupabase({
   authUser = null as typeof MOCK_USER | null,
   authError = null as { message: string } | null,
   session = null as typeof MOCK_SESSION | null,
-  dbResults = null as Array<{ data: unknown; error: { message: string } | null }> | null,
+  dbResults = null as
+    | Array<{ data: unknown; error: { message: string } | null }>
+    | null,
 } = {}) {
   let dbCallIndex = 0;
 
@@ -131,7 +133,9 @@ Deno.test("POST login de usuário comum retorna 200 com papel usuario", async ()
 });
 
 Deno.test("POST login retorna 401 com credenciais inválidas", async () => {
-  const mock = createMockSupabase({ authError: { message: "Invalid credentials" } });
+  const mock = createMockSupabase({
+    authError: { message: "Invalid credentials" },
+  });
 
   const req = new Request("http://localhost/usuarios?action=login", {
     method: "POST",
@@ -160,10 +164,17 @@ Deno.test("POST login retorna 400 quando campos faltam", async () => {
 // GET perfil
 
 Deno.test("GET perfil retorna dados com JWT válido", async () => {
-  const perfil = { nome: "Ana", email: "ana@email.com", telefone: "61999999999", disponibilidade: "manhã" };
+  const perfil = {
+    nome: "Ana",
+    email: "ana@email.com",
+    telefone: "61999999999",
+    disponibilidade: "manhã",
+  };
   const mock = createMockSupabase({ dbData: perfil, authUser: MOCK_USER });
 
-  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", { method: "GET" });
+  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", {
+    method: "GET",
+  });
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 200);
@@ -173,7 +184,9 @@ Deno.test("GET perfil retorna dados com JWT válido", async () => {
 Deno.test("GET perfil retorna 401 sem JWT", async () => {
   const mock = createMockSupabase({ dbData: null });
 
-  const req = new Request("http://localhost/usuarios?email=ana@email.com", { method: "GET" });
+  const req = new Request("http://localhost/usuarios?email=ana@email.com", {
+    method: "GET",
+  });
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 401);
@@ -189,9 +202,15 @@ Deno.test("GET perfil retorna 400 quando email não informado", async () => {
 });
 
 Deno.test("GET perfil retorna 400 quando banco retorna erro", async () => {
-  const mock = createMockSupabase({ dbError: { message: "Não encontrado" }, authUser: MOCK_USER });
+  const mock = createMockSupabase({
+    dbError: { message: "Não encontrado" },
+    authUser: MOCK_USER,
+  });
 
-  const req = reqComToken("http://localhost/usuarios?email=naoexiste@email.com", { method: "GET" });
+  const req = reqComToken(
+    "http://localhost/usuarios?email=naoexiste@email.com",
+    { method: "GET" },
+  );
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 400);
@@ -206,7 +225,11 @@ Deno.test("POST cria conta com dados válidos", async () => {
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "bruno@gmail.com", password: "senha123" }),
+    body: JSON.stringify({
+      name: "Bruno",
+      email: "bruno@gmail.com",
+      password: "senha123",
+    }),
   });
   const res = await handleUsuarios(req, mock);
 
@@ -235,7 +258,11 @@ Deno.test("POST retorna 422 quando email não tem @", async () => {
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "brunoemail.com", password: "senha123" }),
+    body: JSON.stringify({
+      name: "Bruno",
+      email: "brunoemail.com",
+      password: "senha123",
+    }),
   });
   const res = await handleUsuarios(req, mock);
 
@@ -248,7 +275,11 @@ Deno.test("POST retorna 422 quando domínio do email não é permitido", async (
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "bruno@dominioqualquer.xyz", password: "senha123" }),
+    body: JSON.stringify({
+      name: "Bruno",
+      email: "bruno@dominioqualquer.xyz",
+      password: "senha123",
+    }),
   });
   const res = await handleUsuarios(req, mock);
 
@@ -256,12 +287,18 @@ Deno.test("POST retorna 422 quando domínio do email não é permitido", async (
 });
 
 Deno.test("POST retorna 400 quando auth retorna erro (email duplicado)", async () => {
-  const mock = createMockSupabase({ authError: { message: "User already registered" } });
+  const mock = createMockSupabase({
+    authError: { message: "User already registered" },
+  });
 
   const req = new Request("http://localhost/usuarios", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: "Bruno", email: "bruno@gmail.com", password: "senha123" }),
+    body: JSON.stringify({
+      name: "Bruno",
+      email: "bruno@gmail.com",
+      password: "senha123",
+    }),
   });
   const res = await handleUsuarios(req, mock);
 
@@ -271,7 +308,12 @@ Deno.test("POST retorna 400 quando auth retorna erro (email duplicado)", async (
 // PUT
 
 Deno.test("PUT atualiza dados com JWT válido", async () => {
-  const atualizado = { id: "uuid-1", nome: "Ana", email: "ana@email.com", disponibilidade: "tarde" };
+  const atualizado = {
+    id: "uuid-1",
+    nome: "Ana",
+    email: "ana@email.com",
+    disponibilidade: "tarde",
+  };
   const mock = createMockSupabase({ dbData: atualizado, authUser: MOCK_USER });
 
   const req = reqComToken("http://localhost/usuarios?email=ana@email.com", {
@@ -338,7 +380,9 @@ Deno.test("DELETE remove conta com JWT válido", async () => {
     ],
   });
 
-  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", { method: "DELETE" });
+  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", {
+    method: "DELETE",
+  });
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 204);
@@ -347,7 +391,9 @@ Deno.test("DELETE remove conta com JWT válido", async () => {
 Deno.test("DELETE retorna 401 sem JWT", async () => {
   const mock = createMockSupabase({});
 
-  const req = new Request("http://localhost/usuarios?email=ana@email.com", { method: "DELETE" });
+  const req = new Request("http://localhost/usuarios?email=ana@email.com", {
+    method: "DELETE",
+  });
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 401);
@@ -365,7 +411,10 @@ Deno.test("DELETE retorna 400 quando email não informado", async () => {
 Deno.test("DELETE retorna 404 quando usuário não encontrado", async () => {
   const mock = createMockSupabase({ dbData: null, authUser: MOCK_USER });
 
-  const req = reqComToken("http://localhost/usuarios?email=naoexiste@email.com", { method: "DELETE" });
+  const req = reqComToken(
+    "http://localhost/usuarios?email=naoexiste@email.com",
+    { method: "DELETE" },
+  );
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 404);
@@ -380,7 +429,9 @@ Deno.test("DELETE retorna 400 quando banco retorna erro ao deletar", async () =>
     ],
   });
 
-  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", { method: "DELETE" });
+  const req = reqComToken("http://localhost/usuarios?email=ana@email.com", {
+    method: "DELETE",
+  });
   const res = await handleUsuarios(req, mock);
 
   assertEquals(res.status, 400);

--- a/backend/supabase/functions/usuarios/handler.test.ts
+++ b/backend/supabase/functions/usuarios/handler.test.ts
@@ -110,7 +110,7 @@ Deno.test("POST login retorna token com credenciais válidas de admin", async ()
   assertEquals(body.usuario.papel, "admin");
 });
 
-Deno.test("POST login retorna 403 quando usuário não é admin", async () => {
+Deno.test("POST login de usuário comum retorna 200 com papel usuario", async () => {
   const mock = createMockSupabase({
     authUser: MOCK_USER,
     session: MOCK_SESSION,
@@ -124,8 +124,10 @@ Deno.test("POST login retorna 403 quando usuário não é admin", async () => {
   });
   const res = await handleUsuarios(req, mock);
 
-  assertEquals(res.status, 403);
-  assertEquals((await res.json()).autenticado, false);
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.autenticado, true);
+  assertEquals(body.usuario.papel, "usuario");
 });
 
 Deno.test("POST login retorna 401 com credenciais inválidas", async () => {

--- a/backend/supabase/functions/usuarios/handler.ts
+++ b/backend/supabase/functions/usuarios/handler.ts
@@ -1,4 +1,5 @@
 import { corsHeaders } from "../_shared/cors.ts";
+import { validarEmail } from "../_shared/validacao.ts";
 
 // deno-lint-ignore no-explicit-any
 type SupabaseClientLike = any;
@@ -10,6 +11,7 @@ export interface UsuarioPerfil {
   telefone?: string;
   disponibilidade?: string;
   acoes_preferencia?: string[];
+  papel?: "admin" | "usuario";
 }
 
 async function verificarJWT(
@@ -69,12 +71,31 @@ export async function handleUsuarios(
       });
     }
 
+    const { data: perfil } = await supabase
+      .from("usuarios")
+      .select("papel")
+      .eq("id", data.user.id)
+      .single();
+
+    if (!perfil || perfil.papel !== "admin") {
+      return new Response(
+        JSON.stringify({
+          autenticado: false,
+          error: "Acesso restrito a administradores",
+        }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
     return new Response(
       JSON.stringify({
         autenticado: true,
         token: data.session.access_token,
-        usuario: { id: data.user.id, email: data.user.email },
-        user: { id: data.user.id, email: data.user.email },
+        usuario: { id: data.user.id, email: data.user.email, papel: perfil.papel },
+        user: { id: data.user.id, email: data.user.email, papel: perfil.papel },
       }),
       {
         status: 200,
@@ -146,6 +167,7 @@ export async function handleUsuarios(
       telefone?: string;
       disponibilidade?: string;
       acoes_preferencia?: string[];
+      papel?: "admin" | "usuario";
     };
     try {
       body = await req.json();
@@ -159,6 +181,16 @@ export async function handleUsuarios(
     if (!body.name || !body.email || !body.password) {
       return new Response(
         JSON.stringify({ error: "Campos obrigatórios: name, email, password" }),
+        {
+          status: 422,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (!validarEmail(body.email)) {
+      return new Response(
+        JSON.stringify({ error: "E-mail inválido ou domínio não permitido" }),
         {
           status: 422,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -189,8 +221,9 @@ export async function handleUsuarios(
         telefone: body.telefone,
         disponibilidade: body.disponibilidade,
         acoes_preferencia: body.acoes_preferencia,
+        papel: body.papel ?? "admin",
       })
-      .select("id, nome, email, telefone, disponibilidade")
+      .select("id, nome, email, telefone, disponibilidade, papel")
       .single();
 
     if (error) {

--- a/backend/supabase/functions/usuarios/handler.ts
+++ b/backend/supabase/functions/usuarios/handler.ts
@@ -187,8 +187,8 @@ export async function handleUsuarios(
       );
     }
 
-    const { data: authData, error: authError } =
-      await supabase.auth.admin.createUser({
+    const { data: authData, error: authError } = await supabase.auth.admin
+      .createUser({
         email: body.email,
         password: body.password,
         email_confirm: true,

--- a/backend/supabase/functions/usuarios/handler.ts
+++ b/backend/supabase/functions/usuarios/handler.ts
@@ -77,25 +77,14 @@ export async function handleUsuarios(
       .eq("id", data.user.id)
       .single();
 
-    if (!perfil || perfil.papel !== "admin") {
-      return new Response(
-        JSON.stringify({
-          autenticado: false,
-          error: "Acesso restrito a administradores",
-        }),
-        {
-          status: 403,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        },
-      );
-    }
+    const papel = perfil?.papel ?? "usuario";
 
     return new Response(
       JSON.stringify({
         autenticado: true,
         token: data.session.access_token,
-        usuario: { id: data.user.id, email: data.user.email, papel: perfil.papel },
-        user: { id: data.user.id, email: data.user.email, papel: perfil.papel },
+        usuario: { id: data.user.id, email: data.user.email, papel },
+        user: { id: data.user.id, email: data.user.email, papel },
       }),
       {
         status: 200,

--- a/backend/supabase/functions/voluntarios/handler.ts
+++ b/backend/supabase/functions/voluntarios/handler.ts
@@ -82,10 +82,13 @@ export async function handleVoluntarios(
 
   if (req.method === "PUT") {
     if (!id) {
-      return new Response(JSON.stringify({ error: "Parâmetro id obrigatório" }), {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Parâmetro id obrigatório" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     let body: Partial<Voluntario>;
@@ -120,10 +123,13 @@ export async function handleVoluntarios(
 
   if (req.method === "DELETE") {
     if (!id) {
-      return new Response(JSON.stringify({ error: "Parâmetro id obrigatório" }), {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Parâmetro id obrigatório" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     const { error } = await supabase

--- a/backend/supabase/migrations/20260530000000_add_papel_usuarios.sql
+++ b/backend/supabase/migrations/20260530000000_add_papel_usuarios.sql
@@ -1,7 +1,7 @@
 -- RF-01: Autenticar Administrador
 -- Adiciona o papel do usuário para distinguir administradores dos demais.
 alter table public.usuarios
-  add column if not exists papel text not null default 'admin';
+  add column if not exists papel text not null default 'usuario';
 
 alter table public.usuarios
   drop constraint if exists usuarios_papel_check;

--- a/backend/supabase/migrations/20260530000000_add_papel_usuarios.sql
+++ b/backend/supabase/migrations/20260530000000_add_papel_usuarios.sql
@@ -1,0 +1,10 @@
+-- RF-01: Autenticar Administrador
+-- Adiciona o papel do usuário para distinguir administradores dos demais.
+alter table public.usuarios
+  add column if not exists papel text not null default 'admin';
+
+alter table public.usuarios
+  drop constraint if exists usuarios_papel_check;
+
+alter table public.usuarios
+  add constraint usuarios_papel_check check (papel in ('admin', 'usuario'));


### PR DESCRIPTION
# Pull Request

## Descrição

Implementa a autenticação de administrador (RF-01) no backend.

* **Problema:** o sistema precisa distinguir administradores dos demais usuários para liberar a área de gerência, mantendo o login aberto a todos.
* **Funcionalidade:** login via Supabase Edge Function `usuarios`, retornando token JWT e o papel do usuário. Adiciona a coluna `papel` na tabela `usuarios`.
* **Contexto:** base de autenticação/autorização para os demais RFs de gestão.

---

## Issues relacionadas

Closes #67 

---

## Tipo de mudança

* [x] Feature
* [ ] Fix
* [ ] Refactor
* [ ] Doc
* [ ] Test
* [ ] Chore
* [ ] Outra: ___

---

## O que foi feito

* [x] Implementação de lógica
* [ ] Integração com outro subsistema
* [ ] Atualização de documentação
* [ ] Correção de erro
* [ ] Outro: ___

## Descreva os principais pontos:

* Login (`POST /usuarios?action=login`) valida credenciais e retorna `token` + `usuario.papel` (`admin` / `usuario`). Login aberto a qualquer usuário autenticado.
* Coluna `papel` adicionada à tabela `usuarios` (default `admin`, valores `admin`/`usuario`) via migration.
* Cadastro define `papel` (default `admin`); resposta inclui o papel.
* Validação de e-mail no cadastro: exige `@` e domínio conhecido (gmail, outlook, hotmail, etc.), senão 422.
* `verificarJWT` protege rotas autenticadas (GET/PUT/DELETE de perfil).

---

## Como testar

Backend roda em **Deno** (não pnpm):

1. `cd backend`
2. `deno test --allow-env supabase/functions/usuarios/`

> Para subir no Supabase: aplicar a migration `papel` e `supabase functions deploy usuarios`.

## Resultado esperado:

* 22 testes passando.
* Login admin → 200 + token + `papel: "admin"`.
* Login usuário comum → 200 + token + `papel: "usuario"`.
* Credenciais inválidas → 401. Campos faltando → 400. E-mail inválido no cadastro → 422.

---

## Impacto no sistema

* [x] Backend
* [ ] Frontend
* [x] Testes
* [ ] Documentação
* [ ] Outro: ___

Explique o impacto (se houver):

* Nova coluna `papel` em `usuarios` (migration precisa ser aplicada no banco).
* Resposta do login agora inclui `papel` — frontend usa para liberar/esconder a área de gerência.

---

## 📋 Checklist

* [x] Código revisado
* [x] Testado localmente
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebra funcionalidades existentes

---

## 💬 Observações adicionais