### PR TITLE
Feature/backend/rf11 voluntarios

### DIFF
--- a/backend/supabase/functions/voluntarios/handler.test.ts
+++ b/backend/supabase/functions/voluntarios/handler.test.ts
@@ -59,6 +59,79 @@ Deno.test("GET retorna 400 quando banco retorna erro", async () => {
   assertEquals((await res.json()).error, "Erro de conexão");
 });
 
+Deno.test("RF11 - GET retorna voluntários filtrados por nome", async () => {
+  const voluntarios = [
+    {
+      id: "1",
+      nome: "Ana",
+      email: "ana@email.com",
+      area_atuacao: "educacao",
+    },
+  ];
+
+  const mock = createMockSupabase(voluntarios, null, 1);
+
+  const req = new Request("http://localhost/voluntarios?nome=Ana", {
+    method: "GET",
+  } );
+  const res = await handleVoluntarios(req, mock);
+  const body = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(body.data.length, 1);
+  assertEquals(body.data[0].nome, "Ana");
+  assertEquals(body.count, 1);
+});
+
+Deno.test("RF11 - GET retorna voluntários filtrados por área de atuação", async () => {
+  const voluntarios = [
+    {
+      id: "2",
+      nome: "Bruno",
+      email: "bruno@email.com",
+      area_atuacao: "logistica",
+    },
+  ];
+
+  const mock = createMockSupabase(voluntarios, null, 1);
+
+  const req = new Request("http://localhost/voluntarios?area_atuacao=logistica", {
+    method: "GET",
+  } );
+  const res = await handleVoluntarios(req, mock);
+  const body = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(body.data.length, 1);
+  assertEquals(body.data[0].area_atuacao, "logistica");
+  assertEquals(body.count, 1);
+});
+
+Deno.test("RF11 - GET retorna lista vazia quando nenhum voluntário corresponde aos filtros", async () => {
+  const mock = createMockSupabase([], null, 0);
+
+  const req = new Request("http://localhost/voluntarios?nome=Inexistente", {
+    method: "GET",
+  } );
+  const res = await handleVoluntarios(req, mock);
+  const body = await res.json();
+
+  assertEquals(res.status, 200);
+  assertEquals(body.data, []);
+  assertEquals(body.count, 0);
+});
+
+Deno.test("RF11 - GET retorna 400 quando limit é inválido", async () => {
+  const mock = createMockSupabase(null);
+
+  const req = new Request("http://localhost/voluntarios?limit=0", {
+    method: "GET",
+  } );
+  const res = await handleVoluntarios(req, mock);
+
+  assertEquals(res.status, 400);
+});
+
 // POST
 
 Deno.test("POST cria voluntário com dados válidos", async () => {

--- a/backend/supabase/functions/voluntarios/handler.test.ts
+++ b/backend/supabase/functions/voluntarios/handler.test.ts
@@ -4,28 +4,31 @@ import { handleVoluntarios } from "./handler.ts";
 function createMockSupabase(
   data: unknown,
   error: { message: string } | null = null,
+  count: number | null = null,
 ) {
-  const result = { data, error };
+  const result = { data, error, count };
 
-  const chain: Record<string, unknown> = {
+  const thenableChain: Record<string, unknown> = {};
+
+  Object.assign(thenableChain, {
     select: () => thenableChain,
-    insert: () => chain,
-    update: () => chain,
+    insert: () => thenableChain,
+    update: () => thenableChain,
     delete: () => thenableChain,
     eq: () => thenableChain,
+    ilike: () => thenableChain,
+    or: () => thenableChain,
+    order: () => thenableChain,
+    range: () => thenableChain,
     single: () => Promise.resolve(result),
-  };
-
-  const thenableChain = {
-    ...chain,
     then: (
-      resolve: (v: typeof result) => unknown,
-      reject?: (e: unknown) => unknown,
+      resolve: (value: typeof result) => unknown,
+      reject?: (reason: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
-    catch: (reject: (e: unknown) => unknown) =>
+    catch: (reject: (reason: unknown) => unknown) =>
       Promise.resolve(result).catch(reject),
-    finally: (fn: () => void) => Promise.resolve(result).finally(fn),
-  };
+    finally: (callback: () => void) => Promise.resolve(result).finally(callback),
+  });
 
   return { from: () => thenableChain };
 }
@@ -37,13 +40,13 @@ Deno.test("GET retorna lista de voluntários", async () => {
     { id: "1", nome: "Ana", email: "ana@email.com", telefone: "61999999999" },
     { id: "2", nome: "Bruno", email: "bruno@email.com", telefone: null },
   ];
-  const mock = createMockSupabase(voluntarios);
+  const mock = createMockSupabase(voluntarios, null, 2);
 
   const req = new Request("http://localhost/voluntarios", { method: "GET" });
   const res = await handleVoluntarios(req, mock);
 
   assertEquals(res.status, 200);
-  assertEquals(await res.json(), voluntarios);
+  assertEquals(await res.json(), { data: voluntarios, count: 2 });
 });
 
 Deno.test("GET retorna 400 quando banco retorna erro", async () => {

--- a/backend/supabase/functions/voluntarios/handler.ts
+++ b/backend/supabase/functions/voluntarios/handler.ts
@@ -9,6 +9,7 @@ export interface Voluntario {
   email: string;
   telefone?: string;
   disponibilidade?: string;
+  area_atuacao?: string;
   created_at?: string;
 }
 
@@ -24,21 +25,61 @@ export async function handleVoluntarios(
   const id = url.searchParams.get("id");
 
   if (req.method === "GET") {
-    const query = supabase.from("voluntarios").select("*");
-    const { data, error } = id ? await query.eq("id", id) : await query;
+  const nome = url.searchParams.get("nome");
+  const email = url.searchParams.get("email");
+  const telefone = url.searchParams.get("telefone");
+  const disponibilidade = url.searchParams.get("disponibilidade");
+  const areaAtuacao = url.searchParams.get("area_atuacao");
+  const q = url.searchParams.get("q");
+  const limit = Number(url.searchParams.get("limit") ?? "50");
+  const offset = Number(url.searchParams.get("offset") ?? "0");
 
-    if (error) {
-      return new Response(JSON.stringify({ error: error.message }), {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    return new Response(JSON.stringify(data), {
-      status: 200,
+  if (Number.isNaN(limit) || limit < 1 || limit > 100) {
+    return new Response(JSON.stringify({ error: "Parâmetro limit inválido" }), {
+      status: 400,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
+
+  if (Number.isNaN(offset) || offset < 0) {
+    return new Response(JSON.stringify({ error: "Parâmetro offset inválido" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  let query = supabase
+    .from("voluntarios")
+    .select("*", { count: "exact" })
+    .order("nome", { ascending: true })
+    .range(offset, offset + limit - 1);
+
+  if (id) query = query.eq("id", id);
+  if (nome) query = query.ilike("nome", `%${nome}%`);
+  if (email) query = query.ilike("email", `%${email}%`);
+  if (telefone) query = query.ilike("telefone", `%${telefone}%`);
+  if (disponibilidade) query = query.ilike("disponibilidade", `%${disponibilidade}%`);
+  if (areaAtuacao) query = query.ilike("area_atuacao", `%${areaAtuacao}%`);
+  if (q) {
+    query = query.or(
+      `nome.ilike.%${q}%,email.ilike.%${q}%,telefone.ilike.%${q}%,area_atuacao.ilike.%${q}%`,
+    );
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ data: data ?? [], count: count ?? 0 }), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
 
   if (req.method === "POST") {
     let body: Voluntario;

--- a/backend/supabase/migrations/20260606000000_alter_voluntarios_add_area_atuacao.sql
+++ b/backend/supabase/migrations/20260606000000_alter_voluntarios_add_area_atuacao.sql
@@ -1,0 +1,3 @@
+-- RF-11: Listar Voluntários com filtro por área de atuação
+alter table public.voluntarios
+  add column if not exists area_atuacao text null;


### PR DESCRIPTION
# Pull Request

## Descrição

Estende a funcionalidade do endpoint `GET /voluntarios` para permitir a listagem com filtros de voluntários cadastrados (RF-11).

- **Problema:** o sistema precisava apresentar a relação de voluntários permitindo a aplicação de filtros (como nome e área de atuação) para facilitar a localização.
- **Funcionalidade:** ajuste no endpoint existente para aceitar e processar query params como filtros de busca, mantendo a compatibilidade com buscas por ID.
- **Contexto:** extensão da Edge Function `voluntarios` já existente, seguindo o padrão `handler.ts + index.ts + handler.test.ts` do projeto.

---

## Issues relacionadas

Closes #95 

---

## Tipo de mudança

- [x] Feature

---

## O que foi feito

- [x] Implementação de lógica
- [x] Banco de dados (migrations)

## Descreva os principais pontos:

- Extensão do `GET /voluntarios` para suportar filtros via query params (ex: `nome`, `area_atuacao`).
- Manutenção do funcionamento atual para rotas que dependem da listagem ou consulta por ID.
- Retorno organizado e ordenado com suporte a paginação.
- Inclusão da migration `20260606000000_alter_voluntarios_add_area_atuacao.sql` para suportar o filtro por área de atuação.

---

## Como testar

cd backend
deno test supabase/functions/voluntarios/handler.test.ts --allow-env

## Resultado esperado:

`ok | 13 passed | 0 failed` 

---

## Impacto no sistema

- [x] Backend
- [x] Testes

Impacto restrito ao backend na função de voluntários.

---

## 📋 Checklist

- [x] Código revisado
- [x] Testado localmente
- [x] Segue o padrão do projeto
- [x] Issue vinculada corretamente
- [ ] Documentação atualizada (se necessário)
- [x] Não quebra funcionalidades existentes

---

## 💬 Observações adicionais

Foram adicionados novos testes unitários para cobrir os cenários de filtros, garantindo que as funcionalidades existentes não fossem quebradas.