### PR TITLE
fix: adiciona botao de voltar ao inicio na tela de login/cadastro

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -123,6 +123,14 @@ export default function LoginPage() {
 
         <div className="flex items-center justify-center px-5 py-10 sm:px-8 lg:px-12">
           <div className="w-full max-w-md">
+            <button
+              className="mb-6 inline-flex items-center gap-2 text-sm font-bold text-emerald-700 transition hover:text-emerald-900"
+              onClick={() => navigateTo('/')}
+              type="button"
+            >
+              ← Voltar ao início
+            </button>
+
             <div className="lg:hidden">
               <span className="text-sm font-bold uppercase tracking-wide text-emerald-700">Área de doadores e voluntários</span>
               <h1 className="mt-3 text-3xl font-black leading-tight text-slate-950 sm:text-4xl">

--- a/frontend/src/pages/LoginPage.test.jsx
+++ b/frontend/src/pages/LoginPage.test.jsx
@@ -24,6 +24,15 @@ describe('LoginPage', () => {
     expect(screen.getByLabelText(/senha/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /esqueci minha senha/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /voltar ao início/i })).toBeInTheDocument();
+  });
+
+  it('volta para a página inicial ao clicar em voltar ao início', async () => {
+    render(<LoginPage />);
+
+    await userEvent.click(screen.getByRole('button', { name: /voltar ao início/i }));
+
+    expect(window.location.pathname).toBe('/');
   });
 
   it('renderiza modo de criação de conta quando solicitado pela ação protegida', () => {


### PR DESCRIPTION
# Pull Request

## Descrição

Página de login/cadastro não tinha opção de retornar ao início. Como o Header fica oculto nessa rota, o usuário ficava preso na tela sem forma de navegar de volta.

* Qual problema esta PR resolve? Falta de opção de voltar na tela de login/cadastro (issue #83).
* Qual funcionalidade foi implementada? Botão "← Voltar ao início" no topo do formulário de login/cadastro, que leva o usuário de volta para `/`.
* Contexto geral da mudança: mudança pontual em `LoginPage.jsx`, sem alterar lógica de autenticação.

---

## Issues relacionadas

Closes #83

---

## Tipo de mudança

* [ ] Feature
* [x] Fix
* [ ] Refactor
* [ ] Doc
* [ ] Test
* [ ] Chore
* [ ] Outra: ___

---

## O que foi feito

* [x] Implementação de lógica
* [ ] Integração com outro subsistema
* [ ] Atualização de documentação
* [x] Correção de erro
* [ ] Outro: ___

## Descreva os principais pontos:

* Adicionado botão "← Voltar ao início" acima do formulário em `LoginPage.jsx`, usando `navigateTo('/')`.
* Adicionados testes em `LoginPage.test.jsx`: renderização do botão e navegação ao clicar.

---

## Como testar

Explique como validar este PR:

1. cd frontend
2. npm install
3. npm test
4. npm run dev

## Resultado esperado:

Ao acessar `/login`, botão "← Voltar ao início" aparece no topo do formulário. Clicar nele redireciona para a página inicial (`/`).

---

## Impacto no sistema

* [ ] Backend
* [x] Frontend
* [x] Testes
* [ ] Documentação
* [ ] Outro: ___

Explique o impacto (se houver): mudança isolada em `LoginPage.jsx`, sem alteração de rotas ou lógica de autenticação. Não afeta outras páginas.

---

## 📋 Checklist

* [x] Código revisado
* [x] Testado localmente
* [x] Segue o padrão do projeto
* [x] Issue vinculada corretamente
* [ ] Documentação atualizada (se necessário)
* [x] Não quebra funcionalidades existentes

---

## 💬 Observações adicionais

2 testes pré-existentes em `LoginPage.test.jsx` ("cria conta e volta para a ação solicitada", "envia a requisição de login ao clicar em entrar") já falhavam antes desta mudança — confirmado via stash na branch base. Não relacionados a este fix.
